### PR TITLE
INDI::DefaultDevice has ISGetProperties/ISNewXXX/ISSnoopDevice propagation functions for drivers

### DIFF
--- a/drivers/examples/indi_dummy_dome/indi_dummy_dome.cpp
+++ b/drivers/examples/indi_dummy_dome/indi_dummy_dome.cpp
@@ -8,40 +8,6 @@
 // We declare an auto pointer to DummyDome.
 static std::unique_ptr<DummyDome> mydriver(new DummyDome());
 
-// libindidriver will try to link to these functions, so they MUST exist.
-// Here we pass off handling of them to our driver's class.
-
-void ISGetProperties(const char *dev)
-{
-    mydriver->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    mydriver->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    mydriver->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    mydriver->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
-               char *formats[], char *names[], int n)
-{
-    mydriver->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    mydriver->ISSnoopDevice(root);
-}
-
 DummyDome::DummyDome()
 {
     setVersion(CDRIVER_VERSION_MAJOR, CDRIVER_VERSION_MINOR);

--- a/drivers/examples/indi_dummy_dome/indi_dummy_dome.h
+++ b/drivers/examples/indi_dummy_dome/indi_dummy_dome.h
@@ -18,7 +18,7 @@ public:
     virtual bool initProperties() override;
     virtual bool updateProperties() override;
 
-    virtual void ISGetProperties(const char *dev);
+    virtual void ISGetProperties(const char *dev) override;
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
     virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;

--- a/drivers/examples/indi_dummy_dustcap/indi_dummy_dustcap.cpp
+++ b/drivers/examples/indi_dummy_dustcap/indi_dummy_dustcap.cpp
@@ -9,40 +9,6 @@
 // We declare an auto pointer to DummyDustcap.
 static std::unique_ptr<DummyDustcap> mydriver(new DummyDustcap());
 
-// libindidriver will try to link to these functions, so they MUST exist.
-// Here we pass off handling of them to our driver's class.
-
-void ISGetProperties(const char *dev)
-{
-    mydriver->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    mydriver->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    mydriver->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    mydriver->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
-               char *formats[], char *names[], int n)
-{
-    mydriver->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    mydriver->ISSnoopDevice(root);
-}
-
 DummyDustcap::DummyDustcap()
 {
     setVersion(CDRIVER_VERSION_MAJOR, CDRIVER_VERSION_MINOR);

--- a/drivers/examples/indi_dummy_dustcap/indi_dummy_dustcap.h
+++ b/drivers/examples/indi_dummy_dustcap/indi_dummy_dustcap.h
@@ -19,7 +19,7 @@ public:
     virtual bool initProperties() override;
     virtual bool updateProperties() override;
 
-    virtual void ISGetProperties(const char *dev);
+    virtual void ISGetProperties(const char *dev) override;
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
     virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;

--- a/drivers/examples/indi_dummy_filterwheel/indi_dummy_filterwheel.cpp
+++ b/drivers/examples/indi_dummy_filterwheel/indi_dummy_filterwheel.cpp
@@ -8,40 +8,6 @@
 // We declare an auto pointer to DummyFilterWheel.
 static std::unique_ptr<DummyFilterWheel> mydriver(new DummyFilterWheel());
 
-// libindidriver will try to link to these functions, so they MUST exist.
-// Here we pass off handling of them to our driver's class.
-
-void ISGetProperties(const char *dev)
-{
-    mydriver->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    mydriver->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    mydriver->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    mydriver->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
-               char *formats[], char *names[], int n)
-{
-    mydriver->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    mydriver->ISSnoopDevice(root);
-}
-
 DummyFilterWheel::DummyFilterWheel()
 {
     setVersion(CDRIVER_VERSION_MAJOR, CDRIVER_VERSION_MINOR);

--- a/drivers/examples/indi_dummy_filterwheel/indi_dummy_filterwheel.h
+++ b/drivers/examples/indi_dummy_filterwheel/indi_dummy_filterwheel.h
@@ -18,7 +18,7 @@ public:
     virtual bool initProperties() override;
     virtual bool updateProperties() override;
 
-    virtual void ISGetProperties(const char *dev);
+    virtual void ISGetProperties(const char *dev) override;
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
     virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;

--- a/drivers/examples/indi_dummy_focuser/indi_dummy_focuser.cpp
+++ b/drivers/examples/indi_dummy_focuser/indi_dummy_focuser.cpp
@@ -8,40 +8,6 @@
 // We declare an auto pointer to DummyFocuser.
 static std::unique_ptr<DummyFocuser> mydriver(new DummyFocuser());
 
-// libindidriver will try to link to these functions, so they MUST exist.
-// Here we pass off handling of them to our driver's class.
-
-void ISGetProperties(const char *dev)
-{
-    mydriver->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    mydriver->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    mydriver->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    mydriver->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
-               char *formats[], char *names[], int n)
-{
-    mydriver->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    mydriver->ISSnoopDevice(root);
-}
-
 DummyFocuser::DummyFocuser()
 {
     setVersion(CDRIVER_VERSION_MAJOR, CDRIVER_VERSION_MINOR);

--- a/drivers/examples/indi_dummy_focuser/indi_dummy_focuser.h
+++ b/drivers/examples/indi_dummy_focuser/indi_dummy_focuser.h
@@ -13,7 +13,7 @@ public:
     virtual bool initProperties() override;
     virtual bool updateProperties() override;
 
-    virtual void ISGetProperties(const char *dev);
+    virtual void ISGetProperties(const char *dev) override;
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
     virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;

--- a/drivers/examples/indi_dummy_gps/indi_dummy_gps.cpp
+++ b/drivers/examples/indi_dummy_gps/indi_dummy_gps.cpp
@@ -9,40 +9,6 @@
 // We declare an auto pointer to DummyGPS.
 static std::unique_ptr<DummyGPS> mydriver(new DummyGPS());
 
-// libindidriver will try to link to these functions, so they MUST exist.
-// Here we pass off handling of them to our driver's class.
-
-void ISGetProperties(const char *dev)
-{
-    mydriver->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    mydriver->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    mydriver->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    mydriver->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
-               char *formats[], char *names[], int n)
-{
-    mydriver->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    mydriver->ISSnoopDevice(root);
-}
-
 DummyGPS::DummyGPS()
 {
     setVersion(CDRIVER_VERSION_MAJOR, CDRIVER_VERSION_MINOR);

--- a/drivers/examples/indi_dummy_gps/indi_dummy_gps.h
+++ b/drivers/examples/indi_dummy_gps/indi_dummy_gps.h
@@ -18,7 +18,7 @@ public:
     virtual bool initProperties() override;
     virtual bool updateProperties() override;
 
-    virtual void ISGetProperties(const char *dev);
+    virtual void ISGetProperties(const char *dev) override;
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
     virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;

--- a/drivers/examples/indi_dummy_lightbox/indi_dummy_lightbox.cpp
+++ b/drivers/examples/indi_dummy_lightbox/indi_dummy_lightbox.cpp
@@ -9,40 +9,6 @@
 // We declare an auto pointer to DummyLightbox.
 static std::unique_ptr<DummyLightbox> mydriver(new DummyLightbox());
 
-// libindidriver will try to link to these functions, so they MUST exist.
-// Here we pass off handling of them to our driver's class.
-
-void ISGetProperties(const char *dev)
-{
-    mydriver->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    mydriver->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    mydriver->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    mydriver->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
-               char *formats[], char *names[], int n)
-{
-    mydriver->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    mydriver->ISSnoopDevice(root);
-}
-
 DummyLightbox::DummyLightbox() : INDI::LightBoxInterface(this, true)
 {
     setVersion(CDRIVER_VERSION_MAJOR, CDRIVER_VERSION_MINOR);

--- a/drivers/examples/indi_dummy_lightbox/indi_dummy_lightbox.h
+++ b/drivers/examples/indi_dummy_lightbox/indi_dummy_lightbox.h
@@ -19,7 +19,7 @@ public:
     virtual bool initProperties() override;
     virtual bool updateProperties() override;
 
-    virtual void ISGetProperties(const char *dev);
+    virtual void ISGetProperties(const char *dev) override;
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
     virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;

--- a/drivers/examples/indi_mycustomdriver/indi_mycustomdriver.cpp
+++ b/drivers/examples/indi_mycustomdriver/indi_mycustomdriver.cpp
@@ -10,40 +10,6 @@
 // We declare an auto pointer to MyCustomDriver.
 static std::unique_ptr<MyCustomDriver> mydriver(new MyCustomDriver());
 
-// libindidriver will try to link to these functions, so they MUST exist.
-// Here we pass off handling of them to our driver's class.
-
-void ISGetProperties(const char *dev)
-{
-    mydriver->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    mydriver->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    mydriver->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    mydriver->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
-               char *formats[], char *names[], int n)
-{
-    mydriver->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    mydriver->ISSnoopDevice(root);
-}
-
 MyCustomDriver::MyCustomDriver()
 {
     setVersion(CDRIVER_VERSION_MAJOR, CDRIVER_VERSION_MINOR);

--- a/drivers/examples/indi_mycustomdriver/indi_mycustomdriver.h
+++ b/drivers/examples/indi_mycustomdriver/indi_mycustomdriver.h
@@ -18,7 +18,7 @@ public:
     virtual bool initProperties() override;
     virtual bool updateProperties() override;
 
-    virtual void ISGetProperties(const char *dev);
+    virtual void ISGetProperties(const char *dev) override;
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[],
                              int n) override;
     virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[],

--- a/drivers/helpful-functions.md
+++ b/drivers/helpful-functions.md
@@ -146,7 +146,8 @@ These are meant to be called by a driver. These do NOT send any messages to a cl
 #### IS Functions
 
 If a function starts with `IS`, it should NEVER be called by a driver, but is used
-to receive messages from a client. All drivers MUST define these.
+to receive messages from a client.
+All drivers must define these or must inherit from INDI::DefaultDevice.
 
 * `ISGetProperties`
     * This function is called by the framework whenever the driver has received a

--- a/drivers/simple.md
+++ b/drivers/simple.md
@@ -35,40 +35,6 @@ public:
 // We declare an auto pointer to MyCustomDriver.
 static std::unique_ptr<MyCustomDriver> mydriver(new MyCustomDriver());
 
-// libindidriver will try to link to these functions, so they MUST exist.
-// Here we pass off handling of them to our driver's class.
-
-void ISGetProperties(const char *dev)
-{
-    mydriver->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    mydriver->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    mydriver->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    mydriver->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
-               char *formats[], char *names[], int n)
-{
-    mydriver->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    mydriver->ISSnoopDevice(root);
-}
-
 MyCustomDriver::MyCustomDriver()
 {
     setVersion(CDRIVER_VERSION_MAJOR, CDRIVER_VERSION_MINOR);


### PR DESCRIPTION
Hi!

When inheriting from INDI::DefaultDevice, there is no need to implement 'IS' Functions.

Referring to https://github.com/indilib/indi/pull/1375 and https://github.com/indilib/indi/pull/1381
